### PR TITLE
Fix lock-file-dir location in systemd service file

### DIFF
--- a/install-GVM-20_08-src-on-debian.md
+++ b/install-GVM-20_08-src-on-debian.md
@@ -407,7 +407,7 @@ User=gvm
 Group=gvm
 WorkingDirectory=/opt/gvm
 PIDFile=/opt/gvm/var/run/ospd-openvas.pid
-ExecStart=/opt/gvm/bin/ospd-scanner/bin/python /opt/gvm/bin/ospd-scanner/bin/ospd-openvas --pid-file /opt/gvm/var/run/ospd-openvas.pid --unix-socket=/opt/gvm/var/run/ospd.sock --log-file /opt/gvm/var/log/gvm/ospd-scanner.log --lock-file-dir /opt/gvm/var/run/ospd/
+ExecStart=/opt/gvm/bin/ospd-scanner/bin/python /opt/gvm/bin/ospd-scanner/bin/ospd-openvas --pid-file /opt/gvm/var/run/ospd-openvas.pid --unix-socket=/opt/gvm/var/run/ospd.sock --log-file /opt/gvm/var/log/gvm/ospd-scanner.log --lock-file-dir /opt/gvm/var/run/
 Restart=on-failure
 RestartSec=2min
 KillMode=process


### PR DESCRIPTION
See https://github.com/greenbone/ospd-openvas/pull/333 and https://github.com/Atomicorp/gvm/issues/25#issuecomment-687884201 for the reason / some background (had mentioned that in https://community.greenbone.net/t/gvm-20-08-on-debian-10-writeup-created/6339/2 in the past as well but seems that got missed :frowning_face: ).

With this change it will use the share lock file already used by gvmd here:

```
:/opt/gvm/var/run$ ls feed-update.lock 
feed-update.lock
```