### PR TITLE
Add missing but required package for openvas-smb

### DIFF
--- a/install-GVM-20_08-src-on-debian.md
+++ b/install-GVM-20_08-src-on-debian.md
@@ -10,7 +10,7 @@ libldap2-dev doxygen graphviz libradcli-dev libhiredis-dev libpcap-dev bison lib
 gcc-mingw-w64 heimdal-dev libpopt-dev xmltoman redis-server xsltproc libical-dev postgresql \
 postgresql-contrib postgresql-server-dev-all gnutls-bin nmap rpm nsis curl wget fakeroot gnupg \
 sshpass socat snmp smbclient libmicrohttpd-dev libxml2-dev python-polib gettext rsync xml-twig-tools \
-python3-paramiko python3-lxml python3-defusedxml python3-pip python3-psutil virtualenv vim git ;\
+python3-paramiko python3-lxml python3-defusedxml python3-pip python3-psutil virtualenv vim git libunistring-dev ;\
 sudo apt install -y texlive-latex-extra --no-install-recommends ;\
 sudo apt install -y texlive-fonts-recommended ;\
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - ;\


### PR DESCRIPTION
Without this package the build of openvas-smb fails with the following:

```
[ 93%] Linking C executable winexe
/usr/bin/ld: cannot find -lunistring
/usr/bin/ld: cannot find -lunistring
collect2: error: ld returned 1 exit status
make[2]: *** [winexe/CMakeFiles/winexe.dir/build.make:140: winexe/winexe] Error 1
make[1]: *** [CMakeFiles/Makefile2:194: winexe/CMakeFiles/winexe.dir/all] Error 2
make: *** [Makefile:152: all] Error 2
```

Not sure why this wasn't required back then, maybe one of the already installed packages got the dependency to this package dropped?

See:
https://github.com/greenbone/openvas-smb/pull/32
https://community.greenbone.net/t/issue-making-openvas-smb-cannot-find-lunistring/8535
https://github.com/falkowich/comments-sadsloth/issues/9#issuecomment-794364067