### PR TITLE
Change startup order of services

### DIFF
--- a/install-GVM-20_08-src-on-debian.md
+++ b/install-GVM-20_08-src-on-debian.md
@@ -374,7 +374,6 @@ Documentation=man:gsad(8) https://www.greenbone.net
 After=network.target
 Wants=gvmd.service
 
-
 [Service]
 Type=forking
 PIDFile=/opt/gvm/var/run/gsad.pid
@@ -425,10 +424,9 @@ systemctl daemon-reload ;\
 systemctl enable gvmd ;\
 systemctl enable gsad ;\
 systemctl enable ospd-openvas ;\
+systemctl start ospd-openvas ;\
 systemctl start gvmd ;\
-systemctl start gsad ;\
-systemctl start ospd-openvas
-
+systemctl start gsad
 ```
 
 Check that the services are up and running
@@ -487,7 +485,6 @@ md manage:   INFO:2020-08-14 14h10.28 utc:29896: Updating CERT-Bund CVSS max suc
 md manage:   INFO:2020-08-14 14h10.28 utc:29896: sync_cert: Updating CERT info succeeded.
 md manage:   INFO:2020-08-14 14h13.01 utc:29895: Updating VTs in database ... 61397 new VTs, 0 changed VTs
 md manage:   INFO:2020-08-14 14h13.03 utc:29895: Updating VTs in database ... done (61397 VTs).
-
 ```
 The line you shall see when the db is updated is `Updating VTs in database ... done (61397 VTs)`
 


### PR DESCRIPTION
`ospd-openvas` is the first service which should be started because `gvmd` relies on the availability of the `ospd.sock`. In turn `gsad` requires `gvmd` to be running so that a user can login.

This matches the `Wants` calls enforced in the service files.

There were also two superfluous newlines in two parts of the .md file which i have removed as well.